### PR TITLE
unbound: block dns rebinding

### DIFF
--- a/unbound.conf
+++ b/unbound.conf
@@ -14,6 +14,17 @@ server:
     outgoing-port-avoid: 8008 # synapse
     outgoing-port-avoid: 8080 # attestation
 
+    # Block DNS rebinding
+    private-address: 10.0.0.0/8
+    private-address: 172.16.0.0/12
+    private-address: 192.168.0.0/16
+    private-address: fd00::/8
+    private-address: 169.254.0.0/16
+    private-address: fe80::/10
+    private-address: 127.0.0.0/8
+    private-address: ::1/128
+    private-address: ::ffff:0:0/96
+
     # AF21
     ip-dscp: 18
 


### PR DESCRIPTION
Blocking RFC 1918 addresses too is unlikely to be useful on your setup, but may be in case you add something like a VPC in the future.