### PR TITLE
Remove redundant PrivateTmp=true

### DIFF
--- a/systemd/system/nginx.service.d/local.conf
+++ b/systemd/system/nginx.service.d/local.conf
@@ -4,7 +4,6 @@ LockPersonality=true
 NoNewPrivileges=true
 MemoryDenyWriteExecute=true
 PrivateIPC=true
-PrivateTmp=true
 ProcSubset=pid
 ProtectClock=true
 ProtectControlGroups=true


### PR DESCRIPTION
Per this comment, the NGINX service already has

```
PrivateDevices=yes
PrivateTmp=true
```

If the logic to not have `PrivateDevices=yes` in `local.conf` is because the default service already has it, then `PrivateTmp=true` should be removed because it is redundant.