### PR TITLE
Sort NGINX overrides alphabetically

### DIFF
--- a/systemd/system/nginx.service.d/local.conf
+++ b/systemd/system/nginx.service.d/local.conf
@@ -1,8 +1,8 @@
 [Service]
 CapabilityBoundingSet=CAP_CHOWN CAP_DAC_OVERRIDE CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
 LockPersonality=true
-NoNewPrivileges=true
 MemoryDenyWriteExecute=true
+NoNewPrivileges=true
 PrivateIPC=true
 ProcSubset=pid
 ProtectClock=true


### PR DESCRIPTION
Everything is already sorted alphabetically, but for some reason NoNewPrivileges is above MemoryDenyWriteExecute