### PR TITLE
replace bash -c [[ ]] wrapper with test

### DIFF
--- a/deploy-bootloader
+++ b/deploy-bootloader
@@ -25,7 +25,7 @@ for host in ${hosts_all[@]}; do
         fi
     elif [[ ${hosts_type[$host]:-vps} != container ]]; then
         rsync etc/default/grub $remote:/etc/default/grub
-        drive=$(ssh $remote bash -c '[[ -e /dev/sda ]] && echo sda || echo vda')
+        drive=$(ssh $remote 'test -e /dev/sda && echo sda || echo vda')
         ssh $remote grub-install /dev/$drive
         ssh $remote grub-mkconfig -o /boot/grub/grub.cfg
     fi

--- a/session-ticket-keys-sync
+++ b/session-ticket-keys-sync
@@ -12,7 +12,7 @@ if [[ ! -f syncing ]]; then
         echo Syncing from $mirror
         echo
 
-        ssh $mirror "bash -c [[ -f /etc/tls/session-ticket-keys/synced ]]" || continue
+        ssh $mirror "test -f /etc/tls/session-ticket-keys/synced" || continue
 
         rm -rf sync
         mkdir sync


### PR DESCRIPTION
The login shell is fish, which has `test` as a built-in, so the `bash -c` wrapper is unnecessary.